### PR TITLE
Modify repo.pp to work with newer RHEL based releases

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -80,15 +80,15 @@ class ceph::repo (
 
     'RedHat': {
       $enabled = $ensure ? { present => '1', absent => '0', default => absent, }
-      yumrepo { 'ext-epel-6.8':
+      yumrepo { 'ext-epel':
         # puppet versions prior to 3.5 do not support ensure, use enabled instead
         enabled    => $enabled,
-        descr      => 'External EPEL 6.8',
-        name       => 'ext-epel-6.8',
+        descr      => 'External EPEL',
+        name       => 'ext-epel',
         baseurl    => absent,
         gpgcheck   => '0',
         gpgkey     => absent,
-        mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
+        mirrorlist => "https://mirrors.fedoraproject.org/metalink?repo=epel-${::operatingsystemmajrelease}&arch=\$basearch",
         priority   => '20', # prefer ceph repos over EPEL
         tag        => 'ceph',
       }
@@ -98,7 +98,7 @@ class ceph::repo (
         enabled    => $enabled,
         descr      => "External Ceph ${release}",
         name       => "ext-ceph-${release}",
-        baseurl    => "http://ceph.com/rpm-${release}/el6/\$basearch",
+        baseurl    => "http://ceph.com/rpm-${release}/el${::operatingsystemmajrelease}/\$basearch",
         gpgcheck   => '1',
         gpgkey     => 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc',
         mirrorlist => absent,
@@ -111,7 +111,7 @@ class ceph::repo (
         enabled    => $enabled,
         descr      => 'External Ceph noarch',
         name       => "ext-ceph-${release}-noarch",
-        baseurl    => "http://ceph.com/rpm-${release}/el6/noarch",
+        baseurl    => "http://ceph.com/rpm-${release}/el${::operatingsystemmajrelease}/noarch",
         gpgcheck   => '1',
         gpgkey     => 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc',
         mirrorlist => absent,
@@ -119,8 +119,8 @@ class ceph::repo (
         tag        => 'ceph',
       }
 
-      if $extras {
-
+      if $extras and ${::operatingsystemmajrelease} < 7 {
+        # There is no extras repo for RHEL/CentOS 7 currently
         yumrepo { 'ext-ceph-extras':
           enabled    => $enabled,
           descr      => 'External Ceph Extras',
@@ -141,7 +141,7 @@ class ceph::repo (
           enabled    => $enabled,
           descr      => 'FastCGI basearch packages for Ceph',
           name       => 'ext-ceph-fastcgi',
-          baseurl    => 'http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel6-x86_64-basic/ref/master',
+          baseurl    => "http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel${::operatingsystemmajrelease}-x86_64-basic/ref/master",
           gpgcheck   => '1',
           gpgkey     => 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc',
           mirrorlist => absent,


### PR DESCRIPTION
There is a bunch of hard coded references in the repo.pp file that will break using this module on CentOS/RHEL 7 machines. 

I have modified the code to use the ${::operatingsystemmajrelease} to determine the correct OS major version and setup the correct repository links for the server this module is being installed on.
