### PR TITLE
Add missing requirement for automatic hiera lookup on osd profile.

### DIFF
--- a/manifests/profile/osd.pp
+++ b/manifests/profile/osd.pp
@@ -22,6 +22,7 @@
 #
 class ceph::profile::osd {
   require ::ceph::profile::client
+  require ::ceph::profile::base
 
   class { '::ceph::osds':
     args => $ceph::profile::params::osds,


### PR DESCRIPTION
I needed that change in order to get my current configuration within hiera working.