### PR TITLE
Explicitly set the Key Name

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -89,7 +89,7 @@ define ceph::key (
   $inject_keyring = undef,
 ) {
 
-  if $key_name {
+  if $key_name != undef {
     $final_name = $key_name
   } else {
     $final_name = $name


### PR DESCRIPTION
I had trouble configuring my node to be a MON and OSD at the same time. Reason for this was

```
      ceph::key { 'client.bootstrap-osd':
        secret  => $bootstrap_osd_key,
        cap_mon => 'allow profile bootstrap-osd',
      }
```

for MONs, and

```
      ceph::key {'client.bootstrap-osd':
         keyring_path => '/var/lib/ceph/bootstrap-osd/ceph.keyring',
         secret       => $bootstrap_osd_key,
      }
```

for OSDs as suggested in the use cases document, together with the fact that the resource title (client.bootstrap-osd) defines the key name as written into the keyring file. I received duplicate entry errors when running the manifests. 

Instead of using the resource title ($name) as the key name, I introduced a key_name parameter. This allows us the use the key_name of "client.bootstrap-osd" twice on the same node while specifying different resource names.