### PR TITLE
Use systemctl instead of Service

### DIFF
--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -87,6 +87,19 @@ define ceph::mon (
         status   => "status ceph-mon id=${id}",
       }
     # Everything else that is supported by puppet-ceph should run systemd.
+    } elsif $::service_provider == 'systemd' {
+      $init = 'systemd'
+      exec { "enable-ceph-mon-${id}":
+         command => "systemctl enable ceph-mon@${id}",
+         unless  => "systemctl is-enabled ceph-mon@${id}",
+      }
+      Service {
+         name     => "ceph-mon-${id}",
+         provider => $::ceph::params::service_provider,
+         start    => "systemctl start ceph-mon@${id}",
+         stop     => "systemctl stop ceph-mon@${id}",
+         status   => "systemctl status ceph-mon@${id}"
+      }
     } else {
       $init = 'sysvinit'
       Service {
@@ -99,7 +112,6 @@ define ceph::mon (
     }
 
     $mon_service = "ceph-mon-${id}"
-
     if $ensure == present {
 
       $ceph_mkfs = "ceph-mon-mkfs-${id}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class ceph::params (
       $user_radosgw     = 'apache'
       $pkg_fastcgi      = 'mod_fastcgi'
       $pkg_nsstools     = 'nss-tools'
-      $service_provider = 'redhat'
+      $service_provider = 'systemd'
     }
 
     default: {


### PR DESCRIPTION
Currently, we use Service command to manage mon,
But when install the new version of ceph like Jewel,
it can not mapping to the correct systemctl command.
So we should change it to use systemctl directly.

Signed-off-by: Tianqing <tianqing@unitedstack.com>