### PR TITLE
Add upstart service support to ceph::mds

### DIFF
--- a/manifests/mds.pp
+++ b/manifests/mds.pp
@@ -79,12 +79,24 @@ class ceph::mds (
   -> File[$mds_data_real]
   -> Service<| tag == 'ceph-mds' |>
 
-  $mds_service_name = "ceph-mds@${mds_id}"
-
-  service { $mds_service_name:
-    ensure => $mds_ensure,
-    enable => $mds_enable,
-    tag    => ['ceph-mds']
+  # For Ubuntu Trusty system
+  if $::service_provider == 'upstart' {
+    service { 'ceph-mds':
+      ensure   => $mds_ensure,
+      provider => $::service_provider,
+      start    => "start ceph-mon id=${mds_id}",
+      stop     => "stop ceph-mon id=${mds_id}",
+      status   => "status ceph-mon id=${mds_id}",
+      enable   => $mds_enable,
+      tag      => ['ceph-mds']
+    }
+  # Everything else that is supported by puppet-ceph should run systemd.
+  } else {
+    service { "ceph-mds@${mds_id}":
+      ensure => $mds_ensure,
+      enable => $mds_enable,
+      tag    => ['ceph-mds']
+    }
   }
 
   package { $pkg_mds:


### PR DESCRIPTION
In line with ceph::mon, add support for a MDS on Ubuntu Trusty. Without this fix, Puppet outputs a error
on Ubuntu Trusty systems.

Debug: Service[ceph-mds@cephdev0](provider=upstart): Could not find ceph-mds@cephdev0.conf in /etc/init
Debug: Service[ceph-mds@cephdev0](provider=upstart): Could not find ceph-mds@cephdev0.conf in /etc/init.d
Debug: Service[ceph-mds@cephdev0](provider=upstart): Could not find ceph-mds@cephdev0 in /etc/init
Debug: Service[ceph-mds@cephdev0](provider=upstart): Could not find ceph-mds@cephdev0 in /etc/init.d
Debug: Service[ceph-mds@cephdev0](provider=upstart): Could not find ceph-mds@cephdev0.sh in /etc/init
Debug: Service[ceph-mds@cephdev0](provider=upstart): Could not find ceph-mds@cephdev0.sh in /etc/init.d
Error: /Stage[main]/Ceph::Mds/Service[ceph-mds@cephdev0]: Could not evaluate: Could not find init script or upstart conf file for 'ceph-mds@cephdev0'

The ceph-mds package for Trusty only contains upstart init scripts (and systemd), therefor the ceph::mds code
should use the 'ceph-mds' service name.

$ dpkg-deb -c ceph-mds_10.2.7-1trusty_amd64.deb |grep init
drwxr-xr-x root/root         0 2017-04-10 14:18 ./etc/init/
-rw-r--r-- root/root       584 2017-04-10 14:18 ./etc/init/ceph-mds-all-starter.conf
-rw-r--r-- root/root       619 2017-04-10 14:18 ./etc/init/ceph-mds.conf
-rw-r--r-- root/root        93 2017-04-10 14:18 ./etc/init/ceph-mds-all.conf