### PR TITLE
fsid_option was unset when not $fsid.

### DIFF
--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -115,6 +115,8 @@ test -z $(ceph-disk list $(readlink -f ${data}) | egrep -o '[0-9a-f]{8}-([0-9a-f
           logoutput => true,
           timeout   => $exec_timeout,
         }
+      } else {
+        $fsid_option = ""
       }
 
       Exec[$ceph_check_udev] -> Exec[$ceph_prepare]


### PR DESCRIPTION
When no $fsid fsid_option was unset. Causing an Puppet Unknown variable:
'fsid_option' error when strict variables is set. For the line

ceph-disk prepare ${cluster_option} ${fsid_option} $(readlink -f ${data}) $(readlink -f ${journal})

This commit fixes that issue.