### PR TITLE
Convert to use of well-maintained sysctl provider

### DIFF
--- a/manifests/osds.pp
+++ b/manifests/osds.pp
@@ -42,9 +42,9 @@ class ceph::osds(
   create_resources(ceph::osd, $args, $defaults)
 
   if $pid_max {
-    $sysctl_settings = {
-      'kernel.pid_max' => { value => $pid_max },
+    sysctl { 'kernel.pid_max':
+      ensure  => present,
+      value   => $pid_max,
     }
-    ensure_resources(sysctl::value,$sysctl_settings)
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -68,8 +68,8 @@
             "version_requirement": ">=4.10.0 <5.0.0"
         },
         {
-            "name": "duritong/sysctl",
-            "version_requirement": ">=0.0.1 <1.0.0"
+            "name": "herculesteam/augeasproviders_sysctl",
+            "version_requirement": ">=2.2.0 <3.0.0"
         }
     ]
 }


### PR DESCRIPTION
The [`durtong/sysctl`](https://forge.puppet.com/duritong/sysctl) module you use has not been maintained in a couple years whereas [`herculesteam/augeasproviders_sysctl`](https://forge.puppet.com/herculesteam/augeasproviders_sysctl) is actively developed and highly-reviewed. But the namespaces overlap.

In fact, I'm switching from a [sysctl module that I maintain](https://forge.puppet.com/tpdownes/sysctl) in favor of this.

`augeasproviders_sysctl` depends on `herculesteam/augeasproviders_core` so this introduces 2 new modules that must be installed while removing `duritong/sysctl`.

I'm not sure if this also requires changes in CI tests you might be performing.