### PR TITLE
Some fixes for the ceph disk activate part

### DIFF
--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -170,7 +170,7 @@ if ! test -b \$disk ; then
     fi
 fi
 # activate happens via udev when using the entire device
-if ! test -b \$disk || ! test -b \${disk}1 || ! test -b \${disk}p1 ; then
+if ! test -b \$disk && ! ( test -b \${disk}1 || test -b \${disk}p1 ); then
   ceph-disk activate \$disk || true
 fi
 if test -f ${udev_rules_file}.disabled && ( test -b \${disk}1 || test -b \${disk}p1 ); then
@@ -179,6 +179,7 @@ fi
 ",
         unless    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
+ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, active\" ||
 ls -ld /var/lib/ceph/osd/${cluster_name}-* | grep \" $(readlink -f ${data})\$\"
 ",
         logoutput => true,


### PR DESCRIPTION
The "unless" condition for the ceph disk activate part did not work when using block devices as puppet always tried to activate a running OSD again and again. So I introduced an additional check with "ceph-disk list" which checks if the OSD is already active. The test to check if a whole block device gets used was not working for me as well. Udev should activate a whole block device when running ceph (since Infernalis), but for me the module tried to activate a OSD.