### PR TITLE
Fix class redeclaration

### DIFF
--- a/manifests/profile/mon.pp
+++ b/manifests/profile/mon.pp
@@ -36,7 +36,8 @@ class ceph::profile::mon {
     inject_keyring => "/var/lib/ceph/mon/ceph-${::hostname}/keyring",
   }
 
-  if !empty($ceph::profile::params::client_keys) {
+  if !empty($ceph::profile::params::client_keys) and
+     !defined(Class['::ceph::keys']) {
     class { '::ceph::keys':
       args     => $ceph::profile::params::client_keys,
       defaults => $defaults


### PR DESCRIPTION
When running a monitor, manager and OSDs all on the same machine `ceph::keys` gets redeclared by mistake. This fixes it by checking if the class is already defined before declaring it in `ceph::profile::mon`.