### PR TITLE
allow `rgw.' to be used as the client name prefix for rgw

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -94,8 +94,8 @@ define ceph::rgw (
     warning( 'The syslog parameter is unused and deprecated. It will be removed in a future release.' )
   }
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^r(ados)?gw\..+/ {
+    fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 
   ceph_config {

--- a/manifests/rgw/civetweb.pp
+++ b/manifests/rgw/civetweb.pp
@@ -25,8 +25,8 @@ define ceph::rgw::civetweb (
   $rgw_frontends = 'civetweb port=7480',
 ) {
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^r(ados)?gw\..+/ {
+    fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 
   ceph_config {

--- a/manifests/rgw/keystone.pp
+++ b/manifests/rgw/keystone.pp
@@ -94,8 +94,8 @@ define ceph::rgw::keystone (
   $rgw_keystone_implicit_tenants    = true,
 ) {
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^r(ados)?gw\..+/ {
+    fail("Define name must be started with 'r(ados)?gw.' or 'rgw.'")
   }
 
   ceph_config {


### PR DESCRIPTION
I think the restriction itself doesn't need to exist, the manifests seem like they would do the right thing with an arbertary client name.

But `rgw.' specifically is used by the [ceph-ansible](https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-rgw/tasks/start_radosgw.yml#L20) project and would allow one migrating from that to this module to manage their cluster.

