### PR TITLE
Add dmcrypt options for `ceph-disk prepare`

### DIFF
--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -144,7 +144,7 @@ udevadm settle
         unless    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
 disk=$(readlink -f ${data})
-ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, (prepared|active)\" ||
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, (prepared|active)|(\${disk}5?|\${disk}p5?) .*ceph lockbox, (prepared|active), for (\${disk}1?|\${disk}p1?))\" ||
 { test -f \$disk/fsid && test -f \$disk/ceph_fsid && test -f \$disk/magic ;}
 ",
         logoutput => true,
@@ -187,7 +187,7 @@ fi
 ",
         unless    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
-ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, active\" ||
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
 ls -ld /var/lib/ceph/osd/${cluster_name}-* | grep \" $(readlink -f ${data})\$\"
 ",
         logoutput => true,

--- a/spec/defines/ceph_osd_spec.rb
+++ b/spec/defines/ceph_osd_spec.rb
@@ -53,13 +53,13 @@ if ! test -b $disk ; then
         chown -h ceph:ceph $disk
     fi
 fi
-ceph-disk prepare --cluster ceph  $(readlink -f /srv) $(readlink -f '')
+ceph-disk prepare --cluster ceph   $(readlink -f /srv) $(readlink -f '')
 udevadm settle
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
 disk=$(readlink -f /srv)
-ceph-disk list | egrep \" *(${disk}1?|${disk}p1?) .*ceph data, (prepared|active)\" ||
+ceph-disk list | egrep \" *((${disk}1?|${disk}p1?) .*ceph data, (prepared|active)|(${disk}5?|${disk}p5?) .*ceph lockbox, (prepared|active), for (${disk}1?|${disk}p1?))\" ||
 { test -f $disk/fsid && test -f $disk/ceph_fsid && test -f $disk/magic ;}
 ",
         'logoutput' => true
@@ -85,8 +85,159 @@ fi
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
-ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, active\" ||
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
 ls -ld /var/lib/ceph/osd/ceph-* | grep \" $(readlink -f /srv)\$\"
+",
+        'logoutput' => true
+      ) }
+    end
+
+    describe "with dmcrypt enabled" do
+
+      let :title do
+        '/dev/sdc'
+      end
+
+      let :params do
+        {
+          :dmcrypt => true,
+        }
+      end
+
+      it { is_expected.to contain_exec('ceph-osd-check-udev-/dev/sdc').with(
+        'command'   => "/bin/true # comment to satisfy puppet syntax requirements
+# Before Infernalis the udev rules race causing the activation to fail so we
+# disable them. More at: http://www.spinics.net/lists/ceph-devel/msg28436.html
+mv -f /usr/lib/udev/rules.d/95-ceph-osd.rules /usr/lib/udev/rules.d/95-ceph-osd.rules.disabled && udevadm control --reload || true
+",
+       'onlyif'    => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+DISABLE_UDEV=$(ceph --version | awk 'match(\$3, /[0-9]+\\.[0-9]+/) {if (substr(\$3, RSTART, RLENGTH) <= 0.94) {print 1} else { print 0 } }')
+test -f /usr/lib/udev/rules.d/95-ceph-osd.rules && test \$DISABLE_UDEV -eq 1
+",
+       'logoutput' => true,
+      ) }
+      it { is_expected.to contain_exec('ceph-osd-prepare-/dev/sdc').with(
+        'command'   => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+disk=$(readlink -f /dev/sdc)
+if ! test -b $disk ; then
+    echo $disk | egrep -e '^/dev' -q -v
+    mkdir -p $disk
+    if getent passwd ceph >/dev/null 2>&1; then
+        chown -h ceph:ceph $disk
+    fi
+fi
+ceph-disk prepare --cluster ceph --dmcrypt --dmcrypt-key-dir '/etc/ceph/dmcrypt-keys'  $(readlink -f /dev/sdc) $(readlink -f '')
+udevadm settle
+",
+        'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+disk=$(readlink -f /dev/sdc)
+ceph-disk list | egrep \" *((${disk}1?|${disk}p1?) .*ceph data, (prepared|active)|(${disk}5?|${disk}p5?) .*ceph lockbox, (prepared|active), for (${disk}1?|${disk}p1?))\" ||
+{ test -f $disk/fsid && test -f $disk/ceph_fsid && test -f $disk/magic ;}
+",
+        'logoutput' => true
+      ) }
+      it { is_expected.to contain_exec('ceph-osd-activate-/dev/sdc').with(
+        'command'   => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+disk=$(readlink -f /dev/sdc)
+if ! test -b $disk ; then
+    echo $disk | egrep -e '^/dev' -q -v
+    mkdir -p $disk
+    if getent passwd ceph >/dev/null 2>&1; then
+        chown -h ceph:ceph $disk
+    fi
+fi
+# activate happens via udev when using the entire device
+if ! test -b \$disk && ! ( test -b \${disk}1 || test -b \${disk}p1 ); then
+  ceph-disk activate $disk || true
+fi
+if test -f /usr/lib/udev/rules.d/95-ceph-osd.rules.disabled && ( test -b ${disk}1 || test -b ${disk}p1 ); then
+  ceph-disk activate ${disk}1 || true
+fi
+",
+        'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
+ls -ld /var/lib/ceph/osd/ceph-* | grep \" $(readlink -f /dev/sdc)\$\"
+",
+        'logoutput' => true
+      ) }
+    end
+
+    describe "with dmcrypt custom keydir" do
+
+      let :title do
+        '/dev/sdc'
+      end
+
+      let :params do
+        {
+          :dmcrypt         => true,
+          :dmcrypt_key_dir => '/srv/ceph/keys',
+        }
+      end
+
+      it { is_expected.to contain_exec('ceph-osd-check-udev-/dev/sdc').with(
+        'command'   => "/bin/true # comment to satisfy puppet syntax requirements
+# Before Infernalis the udev rules race causing the activation to fail so we
+# disable them. More at: http://www.spinics.net/lists/ceph-devel/msg28436.html
+mv -f /usr/lib/udev/rules.d/95-ceph-osd.rules /usr/lib/udev/rules.d/95-ceph-osd.rules.disabled && udevadm control --reload || true
+",
+       'onlyif'    => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+DISABLE_UDEV=$(ceph --version | awk 'match(\$3, /[0-9]+\\.[0-9]+/) {if (substr(\$3, RSTART, RLENGTH) <= 0.94) {print 1} else { print 0 } }')
+test -f /usr/lib/udev/rules.d/95-ceph-osd.rules && test \$DISABLE_UDEV -eq 1
+",
+       'logoutput' => true,
+      ) }
+      it { is_expected.to contain_exec('ceph-osd-prepare-/dev/sdc').with(
+        'command'   => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+disk=$(readlink -f /dev/sdc)
+if ! test -b $disk ; then
+    echo $disk | egrep -e '^/dev' -q -v
+    mkdir -p $disk
+    if getent passwd ceph >/dev/null 2>&1; then
+        chown -h ceph:ceph $disk
+    fi
+fi
+ceph-disk prepare --cluster ceph --dmcrypt --dmcrypt-key-dir '/srv/ceph/keys'  $(readlink -f /dev/sdc) $(readlink -f '')
+udevadm settle
+",
+        'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+disk=$(readlink -f /dev/sdc)
+ceph-disk list | egrep \" *((${disk}1?|${disk}p1?) .*ceph data, (prepared|active)|(${disk}5?|${disk}p5?) .*ceph lockbox, (prepared|active), for (${disk}1?|${disk}p1?))\" ||
+{ test -f $disk/fsid && test -f $disk/ceph_fsid && test -f $disk/magic ;}
+",
+        'logoutput' => true
+      ) }
+      it { is_expected.to contain_exec('ceph-osd-activate-/dev/sdc').with(
+        'command'   => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+disk=$(readlink -f /dev/sdc)
+if ! test -b $disk ; then
+    echo $disk | egrep -e '^/dev' -q -v
+    mkdir -p $disk
+    if getent passwd ceph >/dev/null 2>&1; then
+        chown -h ceph:ceph $disk
+    fi
+fi
+# activate happens via udev when using the entire device
+if ! test -b \$disk && ! ( test -b \${disk}1 || test -b \${disk}p1 ); then
+  ceph-disk activate $disk || true
+fi
+if test -f /usr/lib/udev/rules.d/95-ceph-osd.rules.disabled && ( test -b ${disk}1 || test -b ${disk}p1 ); then
+  ceph-disk activate ${disk}1 || true
+fi
+",
+        'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
+ls -ld /var/lib/ceph/osd/ceph-* | grep \" $(readlink -f /dev/sdc)\$\"
 ",
         'logoutput' => true
       ) }
@@ -141,13 +292,13 @@ if ! test -b $disk ; then
         chown -h ceph:ceph $disk
     fi
 fi
-ceph-disk prepare --cluster testcluster --cluster-uuid f39ace04-f967-4c3d-9fd2-32af2d2d2cd5 $(readlink -f /srv/data) $(readlink -f /srv/journal)
+ceph-disk prepare --cluster testcluster  --cluster-uuid f39ace04-f967-4c3d-9fd2-32af2d2d2cd5 $(readlink -f /srv/data) $(readlink -f /srv/journal)
 udevadm settle
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
 disk=$(readlink -f /srv/data)
-ceph-disk list | egrep \" *(${disk}1?|${disk}p1?) .*ceph data, (prepared|active)\" ||
+ceph-disk list | egrep \" *((${disk}1?|${disk}p1?) .*ceph data, (prepared|active)|(${disk}5?|${disk}p5?) .*ceph lockbox, (prepared|active), for (${disk}1?|${disk}p1?))\" ||
 { test -f $disk/fsid && test -f $disk/ceph_fsid && test -f $disk/magic ;}
 ",
         'logoutput' => true
@@ -173,7 +324,7 @@ fi
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
-ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, active\" ||
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
 ls -ld /var/lib/ceph/osd/testcluster-* | grep \" $(readlink -f /srv/data)\$\"
 ",
         'logoutput' => true
@@ -210,13 +361,13 @@ if ! test -b $disk ; then
         chown -h ceph:ceph $disk
     fi
 fi
-ceph-disk prepare --cluster ceph  $(readlink -f /dev/nvme0n1) $(readlink -f '')
+ceph-disk prepare --cluster ceph   $(readlink -f /dev/nvme0n1) $(readlink -f '')
 udevadm settle
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
 disk=$(readlink -f /dev/nvme0n1)
-ceph-disk list | egrep \" *(${disk}1?|${disk}p1?) .*ceph data, (prepared|active)\" ||
+ceph-disk list | egrep \" *((${disk}1?|${disk}p1?) .*ceph data, (prepared|active)|(${disk}5?|${disk}p5?) .*ceph lockbox, (prepared|active), for (${disk}1?|${disk}p1?))\" ||
 { test -f $disk/fsid && test -f $disk/ceph_fsid && test -f $disk/magic ;}
 ",
         'logoutput' => true
@@ -242,7 +393,7 @@ fi
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
-ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, active\" ||
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
 ls -ld /var/lib/ceph/osd/ceph-* | grep \" $(readlink -f /dev/nvme0n1)\$\"
 ",
         'logoutput' => true
@@ -279,13 +430,13 @@ if ! test -b $disk ; then
         chown -h ceph:ceph $disk
     fi
 fi
-ceph-disk prepare --cluster ceph  $(readlink -f /dev/cciss/c0d0) $(readlink -f '')
+ceph-disk prepare --cluster ceph   $(readlink -f /dev/cciss/c0d0) $(readlink -f '')
 udevadm settle
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
 disk=$(readlink -f /dev/cciss/c0d0)
-ceph-disk list | egrep \" *(${disk}1?|${disk}p1?) .*ceph data, (prepared|active)\" ||
+ceph-disk list | egrep \" *((${disk}1?|${disk}p1?) .*ceph data, (prepared|active)|(${disk}5?|${disk}p5?) .*ceph lockbox, (prepared|active), for (${disk}1?|${disk}p1?))\" ||
 { test -f $disk/fsid && test -f $disk/ceph_fsid && test -f $disk/magic ;}
 ",
         'logoutput' => true
@@ -311,7 +462,7 @@ fi
 ",
         'unless'    => "/bin/true # comment to satisfy puppet syntax requirements
 set -ex
-ceph-disk list | egrep \" *(\${disk}1?|\${disk}p1?) .*ceph data, active\" ||
+ceph-disk list | egrep \" *((\${disk}1?|\${disk}p1?) .*ceph data, active|(\${disk}5?|\${disk}p5?) .*ceph lockbox, active, for (\${disk}1?|\${disk}p1?))\" ||
 ls -ld /var/lib/ceph/osd/ceph-* | grep \" $(readlink -f /dev/cciss/c0d0)\$\"
 ",
         'logoutput' => true


### PR DESCRIPTION
This PR adds support for creating encrypted OSDs.

Setting the `dmcrypt` parameter will add the `--dmcrypt` and `--dmcrypt-key-dir` parameters to `ceph-disk prepare`. It is also now able to detect the encrypted OSD partition scheme (which uses LUKS and LVM, and uses extended partitions (partition 5)), as well as the different labels ("ceph lockbox").