### PR TITLE
Rgw swift url ceph config support

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -107,6 +107,7 @@ define ceph::rgw (
     "client.${name}/keyring":            value => $keyring_path;
     "client.${name}/log_file":           value => $log_file;
     "client.${name}/user":               value => $user;
+    "client.${name}/rgw_dns_name":       value => $rgw_dns_name;
     "client.${name}/rgw_swift_url":      value => $rgw_swift_url;
   }
 
@@ -119,7 +120,6 @@ define ceph::rgw (
   elsif ( ( $frontend_type == 'apache-fastcgi' ) or ( $frontend_type == 'apache-proxy-fcgi' ) )
   {
     ceph_config {
-      "client.${name}/rgw_dns_name":       value => $rgw_dns_name;
       "client.${name}/rgw_print_continue": value => $rgw_print_continue;
       "client.${name}/rgw_socket_path":    value => $rgw_socket_path;
     }

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -65,7 +65,7 @@
 #   Optional. Default is 'civetweb port=7480'.
 #
 # [*rgw_swift_url*] The URL for the Ceph Object Gateway Swift API.
-#   Optional. Default is http://$fqdn.
+#   Optional. Default is http://$fqdn:7480.
 #
 # Deprecated Parameters:
 #
@@ -87,7 +87,7 @@ define ceph::rgw (
   $rgw_port           = undef,
   $frontend_type      = 'civetweb',
   $rgw_frontends      = 'civetweb port=7480',
-  $rgw_swift_url      = "http://${::fqdn}",
+  $rgw_swift_url      = "http://${::fqdn}:7480",
   $syslog             = undef,
 ) {
 

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -64,6 +64,9 @@
 # [*rgw_frontends*] Arguments to the rgw frontend
 #   Optional. Default is 'civetweb port=7480'.
 #
+# [*rgw_swift_url*] The URL for the Ceph Object Gateway Swift API.
+#   Optional. Default is http://$fqdn.
+#
 # Deprecated Parameters:
 #
 # [*syslog*] Whether or not to log to syslog.
@@ -84,6 +87,7 @@ define ceph::rgw (
   $rgw_port           = undef,
   $frontend_type      = 'civetweb',
   $rgw_frontends      = 'civetweb port=7480',
+  $rgw_swift_url      = "http://${::fqdn}",
   $syslog             = undef,
 ) {
 
@@ -103,6 +107,7 @@ define ceph::rgw (
     "client.${name}/keyring":            value => $keyring_path;
     "client.${name}/log_file":           value => $log_file;
     "client.${name}/user":               value => $user;
+    "client.${name}/rgw_swift_url":      value => $rgw_swift_url;
   }
 
   if($frontend_type == 'civetweb')


### PR DESCRIPTION
I tried to setup a radosgw with civetweb behind a loadbalancer, and radosgw was not working with the swift API. I was getting connection errors.

I was able to solve these errors by defining the `rgw_dns_name` and `rgw_swift_url` Ceph options and here is pull request with the improvements.

Note that the `rgw_dns_name` is an option that was already supported by the `puppet-ceph` module, but it was only used if the `$frontend_type` was set to `apache-....`. Now I have moved the `rgw_dns_name` and `rgw_swift_url` options to the _common_ config.