### PR TITLE
fix(osd.pp): Get fsid parameter from init class of the module

### DIFF
--- a/manifests/osd.pp
+++ b/manifests/osd.pp
@@ -58,7 +58,7 @@
 #   Optional. Defaults to 'ceph_var_lib_t'
 #
 # [*fsid*] The ceph cluster FSID
-#   Optional. Defaults to $::ceph::profile::params::fsid
+#   Optional. Defaults to $::ceph::fsid
 #
 # [*dmcrypt*] Encrypt [data-path] and/or journal devices with dm-crypt.
 #   Optional. Defaults to false.
@@ -75,7 +75,7 @@ define ceph::osd (
   $store_type = undef,
   $exec_timeout = $::ceph::params::exec_timeout,
   $selinux_file_context = 'ceph_var_lib_t',
-  $fsid = $::ceph::profile::params::fsid,
+  $fsid = $::ceph::fsid,
   $dmcrypt = false,
   $dmcrypt_key_dir = '/etc/ceph/dmcrypt-keys',
   ) {


### PR DESCRIPTION
class osd should get the fsid parameter from the init class instead of getting it from a profile shipped with the module.

The current way breaks puppet when you write your own profiles.