### PR TITLE
radosgw - cope with the prefix 'rgw.' as well

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -97,8 +97,8 @@ define ceph::rgw (
     warning( 'The syslog parameter is unused and deprecated. It will be removed in a future release.' )
   }
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^(radosgw|rgw)\..+/ {
+    fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 
   ceph_config {

--- a/manifests/rgw/civetweb.pp
+++ b/manifests/rgw/civetweb.pp
@@ -25,7 +25,7 @@ define ceph::rgw::civetweb (
   $rgw_frontends = 'civetweb port=7480',
 ) {
 
-  unless $name =~ /^radosgw\..+/ {
+  unless $name =~ /^(radosgw|rgw)\..+/ {
     fail("Define name must be started with 'radosgw.'")
   }
 

--- a/manifests/rgw/keystone.pp
+++ b/manifests/rgw/keystone.pp
@@ -71,7 +71,7 @@ define ceph::rgw::keystone (
   $rgw_keystone_implicit_tenants    = true,
 ) {
 
-  unless $name =~ /^radosgw\..+/ {
+  unless $name =~ /^(radosgw|rgw)\..+/ {
     fail("Define name must be started with 'radosgw.'")
   }
 


### PR DESCRIPTION
I'm not sure if my intention is acutally correct, but as I stumbled on this issue:

When using the _bootstrap-rgw_ profile (`caps: [mon] allow profile bootstrap-rgw`), it [enforces](https://github.com/ceph/ceph/blob/8d514b53a282222f8f028c2f820003afea52fda4/src/mon/MonCap.cc#L261) to use the prefix `client.rgw.`.

Right now, _ceph::rgw_ is insisting to use prefix `radosgw.`.