### PR TITLE
make rgw_dns_name be truly optional for multi-hostname configs

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -106,8 +106,16 @@ define ceph::rgw (
     "client.${name}/keyring":            value => $keyring_path;
     "client.${name}/log_file":           value => $log_file;
     "client.${name}/user":               value => $user;
-    "client.${name}/rgw_dns_name":       value => $rgw_dns_name;
     "client.${name}/rgw_swift_url":      value => $rgw_swift_url;
+  }
+  if $rgw_dns_name {
+    ceph_config {
+      "client.${name}/rgw_dns_name": value => $rgw_dns_name;
+    }
+  } else {
+    ceph_config {
+      "client.${name}/rgw_dns_name": ensure => absent;
+    }
   }
 
   if($frontend_type == 'civetweb')


### PR DESCRIPTION
currently setting it to `false` sets domain to "false" which is not usefil
make it so `false` removes setting from the config.

This is needed for example when setting up zonegroup to work on more than one domain (the `hostnames`) setting,
in that case rgw_dns_name must be unset for rgw to work with set up domains.

https://bugs.launchpad.net/puppet-ceph/+bug/1882230