### PR TITLE
Bump puppetlabs apt

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     "dependencies": [
         {
             "name": "puppetlabs/apt",
-            "version_requirement": ">=2.0.0 <4.0.0"
+            "version_requirement": ">=2.0.0 <7.0.0"
         },
         {
             "name": "puppetlabs/apache",


### PR DESCRIPTION
Hi.

I am opening this Pull request as a "request" to bump also puppetlabs-apt.

Also, could you also change sysctl or even remove this? I look at code it is used only to set `kernel.pid_max`. I use a different sysctl module for this.

Will be testing out on my infrastructure to see if new apt version works.