### PR TITLE
Update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The ceph module is intended to leverage all [Ceph](http://ceph.com/) has to offe
 Module Description
 ------------------
 
-The ceph module deploys a [Ceph](http://ceph.com/) cluster ( MON, OSD ), the [Cephfs](http://docs.ceph.com/docs/master/cephfs/) file system and the [RadosGW](http://docs.ceph.com/docs/firefly/radosgw/) object store. It provides integration with various environments ( OpenStack ... ) and components to be used by third party puppet modules that depend on a Ceph cluster.
+The ceph module deploys a [Ceph](http://ceph.com/) cluster ( MON, OSD ), the [Cephfs](http://docs.ceph.com/docs/master/cephfs/) file system and the [RadosGW](https://docs.ceph.com/en/latest/man/8/radosgw/) object store. It provides integration with various environments ( OpenStack ... ) and components to be used by third party puppet modules that depend on a Ceph cluster.
 
 Setup
 -----


### PR DESCRIPTION
https://docs.ceph.com/docs/firefly/radosgw/ returns HTTP 404. The correct location for RadosGW documentation is on CEPH official documentation page: https://docs.ceph.com/en/latest/man/8/radosgw/.