### PR TITLE
Install yum-plugin-priorities only for CentOS <= 7

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -193,9 +193,11 @@ not on ${::operatingsystem}, which can lead to packaging issues.")
           }
         }
 
-        # prefer ceph.com repos over EPEL
-        package { 'yum-plugin-priorities':
-          ensure => present,
+        if Integer($el) < 8 {
+          # prefer ceph.com repos over EPEL
+          package { 'yum-plugin-priorities':
+            ensure => present,
+          }
         }
       }
 


### PR DESCRIPTION
Package `yum-plugin-priorities` is deprecated in favor of dnf functionality: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#package-replacements_changes-to-packages and gives an error on CentOS 8:

```
Error: Execution of '/usr/bin/dnf -d 0 -e 1 -y install yum-plugin-priorities' returned 1: Error: Unable to find a match: yum-plugin-priorities
Error: /Stage[main]/Ceph::Repo/Package[yum-plugin-priorities]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/dnf -d 0 -e 1 -y install yum-plugin-priorities' returned 1: Error: Unable to find a match: yum-plugin-priorities
```

So here is the fix.